### PR TITLE
Add coinflip command

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "bracketSameLine": true,
+  "arrowParens": "avoid"
+}

--- a/src/commands/utility/coinflip.ts
+++ b/src/commands/utility/coinflip.ts
@@ -1,0 +1,15 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js'
+import CommandBuilder from '~/classes/command.classes'
+
+const data = new SlashCommandBuilder().setName('coinflip').setDescription('Does a coin flip')
+
+async function execute(interaction: ChatInputCommandInteraction) {
+  return
+}
+
+export default new CommandBuilder()
+  .setData(data)
+  .setExecutable(execute)
+  .setInformation({
+    description: 'Does a coinflip with a 50/50 outcome',
+  })

--- a/src/commands/utility/coinflip.ts
+++ b/src/commands/utility/coinflip.ts
@@ -31,8 +31,8 @@ function doCoinFlip() {
 // If custom outcome is provided, use that.
 export function getOutcomeAsString(
   outcome: boolean,
-  heads: Nullable<string>,
-  tails: Nullable<string>
+  heads?: Nullable<string>,
+  tails?: Nullable<string>
 ) {
   const actual = outcome ? 'tails' : 'heads'
 

--- a/src/commands/utility/coinflip.ts
+++ b/src/commands/utility/coinflip.ts
@@ -1,31 +1,62 @@
-import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js'
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from 'discord.js'
 import CommandBuilder from '~/classes/command.classes'
+import { Nullable } from '~/types'
 
-const data = new SlashCommandBuilder().setName('coinflip').setDescription('Does a coin flip')
+const data = new SlashCommandBuilder()
+  .setName('coinflip')
+  .setDescription('Does a coin flip')
+  .addStringOption(option =>
+    option.setName('heads').setDescription("Customize 'heads' outcome")
+  )
+  .addStringOption(option =>
+    option.setName('tails').setDescription("Customize 'tails' outcome")
+  )
 
-const OUTCOMES = {
-  "tails": "Tails",
-  "heads": "Heads"
+const DEFAULT_OUTCOMES = {
+  tails: 'Tails',
+  heads: 'Heads',
 }
 
-function doCoinFlip()  {
+function doCoinFlip() {
   return Math.random() > 0.5
 }
 
-function getOutcomeAsString(outcome: boolean) {
-  const actual = outcome ? "tails" : "heads"
+// Exported for testing
+// Takes the outcome as a boolean and returns
+// the corresponding string outcome.
+// If custom outcome is provided, use that.
+export function getOutcomeAsString(
+  outcome: boolean,
+  heads: Nullable<string>,
+  tails: Nullable<string>
+) {
+  const actual = outcome ? 'tails' : 'heads'
 
-  return OUTCOMES[actual]
+  if (actual === 'heads' && heads) return heads
+  if (actual === 'tails' && tails) return tails
+
+  return DEFAULT_OUTCOMES[actual]
 }
 
 async function execute(interaction: ChatInputCommandInteraction) {
-  const outcome = doCoinFlip()
-  const actual = getOutcomeAsString(outcome)
+  // Extract custom outcomes
+  const heads = interaction.options.getString('heads')
+  const tails = interaction.options.getString('tails')
 
-  const embed = new EmbedBuilder()
-  .setColor(0x729c7c)
-  .setTitle(actual)
-  
+  // Do coin flip
+  const outcome = doCoinFlip()
+
+  // Get the actual outcome
+  const actual = getOutcomeAsString(outcome, heads, tails)
+
+  // TODO: Make the embed prettier
+  // Create embed with presentation of outcome
+  const embed = new EmbedBuilder().setColor(0x729c7c).setTitle(actual)
+
   return await interaction.reply({ embeds: [embed] })
 }
 

--- a/src/commands/utility/coinflip.ts
+++ b/src/commands/utility/coinflip.ts
@@ -1,10 +1,32 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js'
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js'
 import CommandBuilder from '~/classes/command.classes'
 
 const data = new SlashCommandBuilder().setName('coinflip').setDescription('Does a coin flip')
 
+const OUTCOMES = {
+  "tails": "Tails",
+  "heads": "Heads"
+}
+
+function doCoinFlip()  {
+  return Math.random() > 0.5
+}
+
+function getOutcomeAsString(outcome: boolean) {
+  const actual = outcome ? "tails" : "heads"
+
+  return OUTCOMES[actual]
+}
+
 async function execute(interaction: ChatInputCommandInteraction) {
-  return
+  const outcome = doCoinFlip()
+  const actual = getOutcomeAsString(outcome)
+
+  const embed = new EmbedBuilder()
+  .setColor(0x729c7c)
+  .setTitle(actual)
+  
+  return await interaction.reply({ embeds: [embed] })
 }
 
 export default new CommandBuilder()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,4 @@
 export * from './command.types'
 export * from './client.types'
+
+export type Nullable<T> = T | null

--- a/tests/commands/utility/coinflip.test.ts
+++ b/tests/commands/utility/coinflip.test.ts
@@ -1,0 +1,37 @@
+import { getOutcomeAsString } from '~/commands/utility/coinflip'
+
+describe('getOutcomeAsString', () => {
+  test("should return 'Heads' when outcome is false", () => {
+    const outcome = false
+
+    const actual = getOutcomeAsString(outcome)
+
+    expect(actual).toBe('Heads')
+  })
+
+  test("should return 'Tails' when outcome is true", () => {
+    const outcome = true
+
+    const actual = getOutcomeAsString(outcome)
+
+    expect(actual).toBe('Tails')
+  })
+
+  test('should return custom outcome when outcome is false and heads is provided', () => {
+    const outcome = false
+    const custom = 'Custom Heads'
+
+    const actual = getOutcomeAsString(outcome, custom)
+
+    expect(actual).toBe(custom)
+  })
+
+  test('should return custom outcome when outcome is true and tails is provided', () => {
+    const outcome = true
+    const custom = 'Custom Tails'
+
+    const actual = getOutcomeAsString(outcome, '', custom)
+
+    expect(actual).toBe(custom)
+  })
+})


### PR DESCRIPTION
Added coinflip command.

Flips coin and presents outcome.

Allows user to customize the outcome with string options that replaces the default outcome.